### PR TITLE
support for automake 1.17

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -56,7 +56,10 @@ else
 fi
 
 echo -n "checking for automake >= $AUTOMAKE_REQUIRED_VERSION ... "
-if (automake-1.16 --version) < /dev/null > /dev/null 2>&1; then
+if (automake-1.17 --version) < /dev/null > /dev/null 2>&1; then
+   AUTOMAKE=automake-1.17
+   ACLOCAL=aclocal-1.17
+elif (automake-1.16 --version) < /dev/null > /dev/null 2>&1; then
    AUTOMAKE=automake-1.16
    ACLOCAL=aclocal-1.16
 elif (automake-1.15 --version) < /dev/null > /dev/null 2>&1; then


### PR DESCRIPTION
On Arch I have installed automake `1.17` and the `./autogen.sh` failed for me. I took a quick look, saw that `1.16` were the highest supported version... I added `1.17` support on top of the `if-statements`... and that's it. 

I were then able to complete the whole process of building the plugin afterwards, successfully.

I thought this might benefit others as well.

Feel free to add any comments. Thanks!